### PR TITLE
Implementar módulo de restaurante y tema oscuro/claro

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,8 @@
-<app-sidebar>
+<ng-container *ngIf="showSidebar; else simple">
+  <app-sidebar>
+    <router-outlet></router-outlet>
+  </app-sidebar>
+</ng-container>
+<ng-template #simple>
   <router-outlet></router-outlet>
-</app-sidebar>
+</ng-template>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,21 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, Router } from '@angular/router';
 import { SidebarComponent } from './layout/sidebar.component';
+import { AuthService } from './services/auth.service';
+import { ThemeService } from './services/theme.service';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, SidebarComponent],
+  imports: [CommonModule, RouterOutlet, SidebarComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {}
+export class AppComponent {
+  constructor(public auth: AuthService, private router: Router, private theme: ThemeService) {}
+
+  get showSidebar(): boolean {
+    return this.router.url !== '/login' && this.auth.isLoggedIn();
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,13 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { RestauranteModule } from './restaurante/restaurante.module';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    importProvidersFrom(RestauranteModule)
+  ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,7 +5,8 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { InventarioComponent } from './inventario/inventario.component';
 import { CostosComponent } from './costos/costos.component';
 import { EmpleadosComponent } from './empleados/empleados.component';
-import { MesasComponent } from './restaurant/mesas/mesas.component';
+import { PlanoVisualComponent } from './restaurante/plano-visual/plano-visual.component';
+import { MesaDetalleComponent } from './restaurante/mesa-detalle/mesa-detalle.component';
 
 export const routes: Routes = [
   { path: 'login', component: LoginComponent },
@@ -34,10 +35,11 @@ export const routes: Routes = [
     data: { roles: ['admin'] }
   },
   {
-    path: 'mesas',
-    component: MesasComponent,
-    canActivate: [roleGuard],
-    data: { roles: ['admin', 'empleado'] }
+    path: 'restaurante',
+    children: [
+      { path: '', component: PlanoVisualComponent, canActivate: [roleGuard], data: { roles: ['admin', 'empleado'] } },
+      { path: 'mesa/:id', component: MesaDetalleComponent, canActivate: [roleGuard], data: { roles: ['admin', 'empleado'] } }
+    ]
   },
   { path: '**', redirectTo: '' }
 ];

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,16 +1,52 @@
-<div class="p-6 space-y-4">
+<div class="p-6 space-y-6" *ngIf="datos">
+  <div class="stats shadow grid grid-cols-1 md:grid-cols-3">
+    <div class="stat">
+      <div class="stat-title">Ventas Diarias</div>
+      <div class="stat-value">$ {{ datos.ventas.dia }}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-title">Ventas Semanales</div>
+      <div class="stat-value">$ {{ datos.ventas.semana }}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-title">Ventas Mensuales</div>
+      <div class="stat-value">$ {{ datos.ventas.mes }}</div>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow">
+    <div class="card-body">
+      <h2 class="card-title">Productos más vendidos</h2>
+      <ul class="list-disc pl-5">
+        <li *ngFor="let p of datos.productosMasVendidos">{{ p }}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card bg-base-100 shadow">
+    <div class="card-body">
+      <h2 class="card-title">Horarios más activos</h2>
+      <p>{{ datos.horasActivas.join(', ') }}</p>
+    </div>
+  </div>
+
   <div class="stats shadow">
     <div class="stat">
-      <div class="stat-title">Ventas Totales</div>
-      <div class="stat-value">$ {{ resumen.total }}</div>
+      <div class="stat-title">Costo Total</div>
+      <div class="stat-value">$ {{ datos.costos }}</div>
     </div>
     <div class="stat">
-      <div class="stat-title">Mesas Ocupadas</div>
-      <div class="stat-value">{{ resumen.mesasOcupadas }}</div>
+      <div class="stat-title">Ingreso Total</div>
+      <div class="stat-value">$ {{ datos.ingresos }}</div>
     </div>
-    <div class="stat">
-      <div class="stat-title">Pedidos Pendientes</div>
-      <div class="stat-value">{{ resumen.pedidosPendientes }}</div>
+  </div>
+
+  <div class="card bg-base-100 shadow" *ngIf="datos.alertas.length">
+    <div class="card-body">
+      <h2 class="card-title">Alertas de Inventario</h2>
+      <ul class="list-disc pl-5">
+        <li *ngFor="let a of datos.alertas">{{ a }}</li>
+      </ul>
     </div>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -9,10 +9,10 @@ import { MockDataService } from '../mock/mock-data.service';
   templateUrl: './dashboard.component.html'
 })
 export class DashboardComponent implements OnInit {
-  resumen: any;
+  datos: any;
   constructor(private data: MockDataService) { }
 
   ngOnInit() {
-    this.resumen = this.data.getVentasResumen();
+    this.datos = this.data.getDashboardStats();
   }
 }

--- a/src/app/layout/sidebar.component.html
+++ b/src/app/layout/sidebar.component.html
@@ -11,7 +11,8 @@
       <li *ngIf="auth.userRole === 'admin'"><a routerLink="/inventario">Inventario</a></li>
       <li *ngIf="auth.userRole === 'admin'"><a routerLink="/costos">Costos</a></li>
       <li *ngIf="auth.userRole === 'admin'"><a routerLink="/empleados">Empleados</a></li>
-      <li><a routerLink="/mesas">Gestión de Mesas</a></li>
+      <li><a routerLink="/restaurante">Gestión de Mesas</a></li>
+      <li><a (click)="theme.toggle()">Cambiar Tema</a></li>
       <li><a (click)="auth.logout()" routerLink="/login">Salir</a></li>
     </ul>
   </div>

--- a/src/app/layout/sidebar.component.ts
+++ b/src/app/layout/sidebar.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../services/auth.service';
+import { ThemeService } from '../services/theme.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -11,5 +12,5 @@ import { AuthService } from '../services/auth.service';
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent {
-  constructor(public auth: AuthService) {}
+  constructor(public auth: AuthService, public theme: ThemeService) {}
 }

--- a/src/app/mock/mock-data.service.ts
+++ b/src/app/mock/mock-data.service.ts
@@ -10,6 +10,17 @@ export class MockDataService {
     };
   }
 
+  getDashboardStats() {
+    return {
+      ventas: { dia: 1200, semana: 8000, mes: 32000 },
+      productosMasVendidos: ['Pizza', 'Hamburguesa', 'Refresco'],
+      horasActivas: ['12:00-14:00', '19:00-21:00'],
+      costos: 15000,
+      ingresos: 32000,
+      alertas: ['Queso bajo', 'Salsa de tomate vencida']
+    };
+  }
+
   getInventario() {
     return [
       {

--- a/src/app/restaurante/mesa-detalle/mesa-detalle.component.html
+++ b/src/app/restaurante/mesa-detalle/mesa-detalle.component.html
@@ -1,0 +1,34 @@
+<div class="p-6 space-y-4" *ngIf="mesa">
+  <h2 class="text-2xl font-bold">{{ mesa.nombre }}</h2>
+  <p>Mesonero: {{ mesa.mesonero || 'Sin asignar' }}</p>
+  <div class="flex gap-2 items-center">
+    <input class="input input-bordered" placeholder="Mesonero" [(ngModel)]="nuevoMesonero" />
+    <button class="btn btn-sm" (click)="asignarMesonero()">Asignar</button>
+  </div>
+
+  <p class="font-semibold">Estado:
+    <span [ngClass]="mesa.abierta ? 'text-success' : 'text-warning'">
+      {{ mesa.abierta ? 'Abierta' : 'Cerrada' }}
+    </span>
+  </p>
+  <button class="btn btn-primary btn-sm" (click)="abrirMesa()" *ngIf="!mesa.abierta">Abrir Mesa</button>
+
+  <div *ngIf="mesa.abierta" class="space-y-2">
+    <button class="btn btn-sm" (click)="mostrarPedido = !mostrarPedido">Agregar Pedido</button>
+    <app-pedido *ngIf="mostrarPedido" [mesa]="mesa"></app-pedido>
+
+    <div *ngFor="let o of mesa.ordenes" class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h3 class="font-bold">Orden #{{ o.id }} - {{ o.estado }}</h3>
+        <p>Creado por: {{ o.creadoPor }} el {{ o.fecha | date:'short' }}</p>
+        <ul class="list-disc pl-5">
+          <li *ngFor="let p of o.productos">{{ p.cantidad }} x {{ p.nombre }} - {{ p.precio | currency:'USD':'symbol' }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <button class="btn btn-outline btn-sm" (click)="mostrarTicket = !mostrarTicket">Ver Ticket</button>
+    <app-ticket *ngIf="mostrarTicket" [mesa]="mesa"></app-ticket>
+  </div>
+  <a routerLink="/restaurante" class="btn btn-outline mt-4">Volver</a>
+</div>

--- a/src/app/restaurante/mesa-detalle/mesa-detalle.component.ts
+++ b/src/app/restaurante/mesa-detalle/mesa-detalle.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RestauranteService, Mesa } from '../../services/restaurante.service';
+
+@Component({
+  selector: 'app-mesa-detalle',
+  standalone: false,
+  templateUrl: './mesa-detalle.component.html'
+})
+export class MesaDetalleComponent implements OnInit {
+  mesa?: Mesa;
+  nuevoMesonero = '';
+  mostrarPedido = false;
+  mostrarTicket = false;
+
+  constructor(private route: ActivatedRoute, private router: Router, private restaurante: RestauranteService) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.mesa = this.restaurante.getMesa(id);
+  }
+
+  asignarMesonero() {
+    if (this.mesa) {
+      this.mesa.mesonero = this.nuevoMesonero;
+      this.nuevoMesonero = '';
+    }
+  }
+
+  abrirMesa() {
+    if (this.mesa) {
+      this.mesa.abierta = true;
+    }
+  }
+}

--- a/src/app/restaurante/pedido/pedido.component.html
+++ b/src/app/restaurante/pedido/pedido.component.html
@@ -1,0 +1,31 @@
+<div class="card bg-base-200 shadow mt-2">
+  <div class="card-body space-y-2">
+    <div class="flex gap-2 items-center">
+      <select class="select select-bordered" [(ngModel)]="seleccionado">
+        <option *ngFor="let p of productosDisponibles" [ngValue]="p">{{ p.nombre }} - {{ p.precio | currency:'USD':'symbol' }}</option>
+      </select>
+      <input type="number" class="input input-bordered w-20" [(ngModel)]="cantidad" />
+      <button class="btn btn-sm" (click)="agregar()">Agregar</button>
+    </div>
+
+    <table class="table table-zebra w-full" *ngIf="items.length">
+      <thead>
+        <tr><th>Prod.</th><th>Cant.</th><th>Precio</th></tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let i of items">
+          <td>{{ i.nombre }}</td>
+          <td>{{ i.cantidad }}</td>
+          <td>{{ i.precio | currency:'USD':'symbol' }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="flex gap-2 items-center">
+      <span>Total: {{ total | currency:'USD':'symbol' }}</span>
+      <input type="number" class="input input-bordered w-20" [(ngModel)]="dividirEntre" />
+      <span>Por persona: {{ porPersona | currency:'USD':'symbol' }}</span>
+    </div>
+    <button class="btn btn-primary btn-sm" (click)="guardar()">Guardar Pedido</button>
+  </div>
+</div>

--- a/src/app/restaurante/pedido/pedido.component.ts
+++ b/src/app/restaurante/pedido/pedido.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input } from '@angular/core';
+import { RestauranteService, Mesa, ProductoPedido } from '../../services/restaurante.service';
+
+@Component({
+  selector: 'app-pedido',
+  standalone: false,
+  templateUrl: './pedido.component.html'
+})
+export class PedidoComponent {
+  @Input() mesa!: Mesa;
+  productosDisponibles: { nombre: string; precio: number }[] = [];
+  items: ProductoPedido[] = [];
+  seleccionado: { nombre: string; precio: number } | undefined;
+  cantidad = 1;
+  dividirEntre = 1;
+
+  constructor(private restaurante: RestauranteService) {
+    this.productosDisponibles = this.restaurante.getProductos();
+    this.seleccionado = this.productosDisponibles[0];
+  }
+
+  agregar() {
+    if (!this.seleccionado) return;
+    this.items.push({ nombre: this.seleccionado.nombre, precio: this.seleccionado.precio, cantidad: this.cantidad });
+    this.cantidad = 1;
+  }
+
+  guardar() {
+    this.restaurante.agregarOrden(this.mesa.id, this.items);
+    this.items = [];
+  }
+
+  get total(): number {
+    return this.items.reduce((sum, i) => sum + i.precio * i.cantidad, 0);
+  }
+
+  get porPersona(): number {
+    return this.dividirEntre > 0 ? this.total / this.dividirEntre : this.total;
+  }
+}

--- a/src/app/restaurante/plano-visual/plano-visual.component.html
+++ b/src/app/restaurante/plano-visual/plano-visual.component.html
@@ -1,0 +1,11 @@
+<div class="p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div *ngFor="let m of mesas" class="card bg-base-100 shadow">
+    <div class="card-body">
+      <h2 class="card-title">{{ m.nombre }}</h2>
+      <p [ngClass]="m.abierta ? 'text-error' : 'text-success'">
+        {{ m.abierta ? 'Ocupada' : 'Libre' }}
+      </p>
+      <button class="btn btn-primary btn-sm" (click)="detalle(m.id)">Abrir</button>
+    </div>
+  </div>
+</div>

--- a/src/app/restaurante/plano-visual/plano-visual.component.ts
+++ b/src/app/restaurante/plano-visual/plano-visual.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { RestauranteService, Mesa } from '../../services/restaurante.service';
+
+@Component({
+  selector: 'app-plano-visual',
+  standalone: false,
+  templateUrl: './plano-visual.component.html'
+})
+export class PlanoVisualComponent implements OnInit {
+  mesas: Mesa[] = [];
+  constructor(private restaurante: RestauranteService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.mesas = this.restaurante.getMesas();
+  }
+
+  detalle(id: number) {
+    this.router.navigate(['/restaurante/mesa', id]);
+  }
+}

--- a/src/app/restaurante/restaurante.module.ts
+++ b/src/app/restaurante/restaurante.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { PlanoVisualComponent } from './plano-visual/plano-visual.component';
+import { MesaDetalleComponent } from './mesa-detalle/mesa-detalle.component';
+import { PedidoComponent } from './pedido/pedido.component';
+import { TicketComponent } from './ticket/ticket.component';
+
+@NgModule({
+  declarations: [
+    PlanoVisualComponent,
+    MesaDetalleComponent,
+    PedidoComponent,
+    TicketComponent
+  ],
+  imports: [CommonModule, FormsModule, RouterModule],
+  exports: [PlanoVisualComponent, MesaDetalleComponent]
+})
+export class RestauranteModule {}

--- a/src/app/restaurante/ticket/ticket.component.html
+++ b/src/app/restaurante/ticket/ticket.component.html
@@ -1,0 +1,12 @@
+<div class="card bg-base-200 shadow mt-2">
+  <div class="card-body">
+    <h3 class="card-title">Ticket</h3>
+    <div *ngFor="let o of mesa.ordenes" class="border-b py-1">
+      <p class="font-semibold">Orden #{{ o.id }} - {{ o.estado }}</p>
+      <ul class="list-disc pl-5">
+        <li *ngFor="let p of o.productos">{{ p.cantidad }} x {{ p.nombre }} - {{ p.precio | currency:'USD':'symbol' }}</li>
+      </ul>
+    </div>
+    <p class="font-bold mt-2">Total: {{ total | currency:'USD':'symbol' }}</p>
+  </div>
+</div>

--- a/src/app/restaurante/ticket/ticket.component.ts
+++ b/src/app/restaurante/ticket/ticket.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { Mesa } from '../../services/restaurante.service';
+
+@Component({
+  selector: 'app-ticket',
+  standalone: false,
+  templateUrl: './ticket.component.html'
+})
+export class TicketComponent {
+  @Input() mesa!: Mesa;
+
+  get total(): number {
+    return this.mesa.ordenes.reduce((sum, o) =>
+      sum + o.productos.reduce((s, p) => s + p.precio * p.cantidad, 0)
+    , 0);
+  }
+}

--- a/src/app/services/restaurante.service.ts
+++ b/src/app/services/restaurante.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export type EstadoOrden = 'pendiente' | 'en cocina' | 'servido' | 'pagado';
+
+export interface ProductoPedido {
+  nombre: string;
+  precio: number;
+  cantidad: number;
+}
+
+export interface Orden {
+  id: number;
+  productos: ProductoPedido[];
+  estado: EstadoOrden;
+  creadoPor: string;
+  fecha: Date;
+}
+
+export interface Mesa {
+  id: number;
+  nombre: string;
+  mesonero?: string;
+  abierta: boolean;
+  ordenes: Orden[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class RestauranteService {
+  private mesas: Mesa[] = [
+    { id: 1, nombre: 'Mesa 1', abierta: false, ordenes: [] },
+    { id: 2, nombre: 'Mesa 2', abierta: false, ordenes: [] },
+    { id: 3, nombre: 'Mesa 3', abierta: false, ordenes: [] },
+    { id: 4, nombre: 'Mesa 4', abierta: false, ordenes: [] }
+  ];
+
+  private productos = [
+    { nombre: 'Pizza', precio: 10 },
+    { nombre: 'Hamburguesa', precio: 8 },
+    { nombre: 'Refresco', precio: 2 }
+  ];
+
+  constructor(private auth: AuthService) {}
+
+  getMesas(): Mesa[] {
+    return this.mesas;
+  }
+
+  getMesa(id: number): Mesa | undefined {
+    return this.mesas.find(m => m.id === id);
+  }
+
+  getProductos() {
+    return this.productos;
+  }
+
+  agregarOrden(mesaId: number, productos: ProductoPedido[]): void {
+    const mesa = this.getMesa(mesaId);
+    if (!mesa) { return; }
+    const orden: Orden = {
+      id: mesa.ordenes.length + 1,
+      productos,
+      estado: 'pendiente',
+      creadoPor: this.auth.userRole ? this.auth.userRole : 'desconocido',
+      fecha: new Date()
+    };
+    mesa.ordenes.push(orden);
+    mesa.abierta = true;
+  }
+}

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+export type Theme = 'cmyk' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private current: Theme = 'cmyk';
+
+  constructor() {
+    this.apply(this.current);
+  }
+
+  toggle() {
+    this.current = this.current === 'cmyk' ? 'dark' : 'cmyk';
+    this.apply(this.current);
+  }
+
+  private apply(theme: Theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+
+  get theme(): Theme {
+    return this.current;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="cmyk">
 <head>
   <meta charset="utf-8">
   <title>B8CollegeFront</title>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,6 @@ export default {
   },
   plugins: [require('daisyui')],
   daisyui: {
-    themes: ['light', 'dark']
+    themes: ['cmyk', 'dark']
   }
 };


### PR DESCRIPTION
## Summary
- añadir `RestauranteModule` con componentes para mesas, pedidos y tickets
- crear servicio de restaurante para manejar mesas y órdenes
- actualizar Dashboard para mostrar métricas de ventas, productos y alertas
- ocultar el menú en la pantalla de login
- implementar cambio de tema `cmyk`/`dark` con DaisyUI
- actualizar rutas y configuración de la aplicación

## Testing
- `npx ng build`
- `npm test` *(falló: falta @tailwindcss/postcss)*

------
https://chatgpt.com/codex/tasks/task_e_6850cdade1648332b4ce143e00b7b6a4